### PR TITLE
Remove line setting Block.LineHeight to 1

### DIFF
--- a/Emoji.Wpf/RichTextBox.xaml.cs
+++ b/Emoji.Wpf/RichTextBox.xaml.cs
@@ -69,7 +69,6 @@ namespace Emoji.Wpf
     {
         public RichTextBox()
         {
-            SetValue(Block.LineHeightProperty, 1.0);
             DataObject.AddCopyingHandler(this, new DataObjectCopyingEventHandler(OnCopy));
         }
 


### PR DESCRIPTION
I had a binding on the RichTextBox like: 

```
Block.LineHeight="{Binding ActualHeight, ElementName=itemKey}" 
Block.LineStackingStrategy="BlockLineHeight"
```

This line I've removed here was breaking it! :)