### PR TITLE
ShowOnlyRenderable on Picker

### DIFF
--- a/Emoji.Wpf/Internal/Data.cs
+++ b/Emoji.Wpf/Internal/Data.cs
@@ -112,6 +112,9 @@ namespace Emoji.Wpf
             public IEnumerable<IEnumerable<Emoji>> EmojiChunkList
                 => EmojiList.Chunk(8);
 
+            public IEnumerable<IEnumerable<Emoji>> EmojiRenderableChunkList
+                => EmojiList.Where(e => e.Renderable).Chunk(8);
+
             public IEnumerable<Emoji> EmojiList
                 => from s in SubGroups
                    from e in s.EmojiList
@@ -129,6 +132,7 @@ namespace Emoji.Wpf
                 Name = name,
                 Text = sequence,
                 SubGroup = predecessor.SubGroup,
+                Renderable = Typeface.CanRender(sequence),
             };
             var list = predecessor.SubGroup.EmojiList;
             list.Insert(list.IndexOf(predecessor) + 1, entry);

--- a/Emoji.Wpf/Internal/OpenTypeFont.cs
+++ b/Emoji.Wpf/Internal/OpenTypeFont.cs
@@ -152,8 +152,7 @@ namespace Emoji.Wpf
         /// <param name="s"></param>
         /// <returns></returns>
         public bool CanRender(string s)
-            => StringToGlyphPlans(s, use_gpos: false)
-                   .All(g => g.glyphIndex != 0 && g.glyphIndex != ZwjGlyph);
+            => StringToGlyphPlans(s, use_gpos: false).Any(g => g.glyphIndex != 0 && g.glyphIndex != ZwjGlyph);
 
         internal IEnumerable<UnscaledGlyphPlan> StringToGlyphPlans(string s, bool use_gpos = true)
         {

--- a/Emoji.Wpf/Picker.xaml
+++ b/Emoji.Wpf/Picker.xaml
@@ -91,7 +91,7 @@
                 <DataTemplate>
                     <StackPanel Orientation="Vertical">
                         <TextBlock Margin="4" Text="{Binding Name}" FontStyle="Italic"/>
-                        <ListView Name="EmojiListView" ItemsSource="{Binding EmojiChunkList}"
+                        <ListView Name="EmojiListView"
                                   BorderThickness="0"
                                   MaxHeight="320" Height="Auto" Padding="0" Margin="1"
                                   VirtualizingStackPanel.IsVirtualizing="True"
@@ -133,6 +133,16 @@
                                     </ItemsControl>
                                 </DataTemplate>
                             </ListView.ItemTemplate>
+                            <ListView.Style>
+                                <Style TargetType="ListView">
+                                    <Setter Property="ItemsSource" Value="{Binding EmojiChunkList}"></Setter>
+                                    <Style.Triggers>
+                                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type emoji:Picker}},Path=ShowOnlyRenderable}" Value="True">
+                                            <Setter Property="ItemsSource" Value="{Binding EmojiRenderableChunkList}"></Setter>
+                                        </DataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </ListView.Style>
                         </ListView>
                     </StackPanel>
                 </DataTemplate>

--- a/Emoji.Wpf/Picker.xaml.cs
+++ b/Emoji.Wpf/Picker.xaml.cs
@@ -65,6 +65,15 @@ namespace Emoji.Wpf
             set => SetValue(SelectionProperty, value);
         }
 
+        /// <summary>
+        /// Show only emojis that can be rendered with the installed font
+        /// </summary>
+        public bool ShowOnlyRenderable
+        {
+            get;
+            set;
+        }
+
         private void OnSelectionChanged(string s)
         {
             var is_disabled = string.IsNullOrEmpty(s);


### PR DESCRIPTION
- Add `ShowOnlyRenderable` on picker control which allows to hide emojis that can't be rendered
- Tweak `CanRender` to accept emoji with at least one valid glyph.

Closes #40