### PR TITLE
Fix some emojis with Twemoji

### DIFF
--- a/Emoji.Wpf/Internal/Data.cs
+++ b/Emoji.Wpf/Internal/Data.cs
@@ -265,7 +265,7 @@ namespace Emoji.Wpf
                     var emoji = new Emoji
                     {
                         Name = name,
-                        Text = text,
+                        Text = unqualified,
                         SubGroup = current_subgroup,
                         Renderable = Typeface.CanRender(text),
                     };


### PR DESCRIPTION
Very simple fix (maybe too naive) for rendering issues with emojis containing U+FE0F (with Twemoji).

![image](https://user-images.githubusercontent.com/15875066/149673518-21eef114-d2b2-4e98-aab2-805c1a78b8fa.png)
